### PR TITLE
Fix for small values of a (1e-7 and below)

### DIFF
--- a/pkg/src/interface.c
+++ b/pkg/src/interface.c
@@ -196,11 +196,37 @@ SEXP R_triangulate (SEXP P, SEXP PB, SEXP PA, SEXP S, SEXP SB, SEXP(H), SEXP a, 
     strcat(flags, "c");
   }
   if (isReal(a)) {
-    sprintf(opts, "a%f", *REAL(a));
+    int i;
+    TRIREAL y = 1;
+    // 100 digits are probably enough
+    for (i=0; i<100; ++i) {
+      if (*REAL(a) >= y) {
+        break;
+      }
+      y /= 10;
+    }
+    // Allow for 6 additional significant digits
+    i += 6;
+    char fstr[110];
+    sprintf(fstr, "a%%.%df\n", i);
+    sprintf(opts, fstr, *REAL(a));
     strcat(flags, opts);
   }
   if (isReal(q)) {
-    sprintf(opts, "q%f", *REAL(q));
+    int i;
+    TRIREAL y = 1;
+    // 100 digits are probably enough
+    for (i=0; i<100; ++i) {
+      if (*REAL(q) >= y) {
+        break;
+      }
+      y /= 10;
+    }
+    // Allow for 6 additional significant digits
+    i += 6;
+    char fstr[110];
+    sprintf(fstr, "q%%.%df\n", i);
+    sprintf(opts, fstr, *REAL(q));
     strcat(flags, opts);
   }
   if (isLogical(Y)) {

--- a/pkg/tests/testthat/test-triangulate.R
+++ b/pkg/tests/testthat/test-triangulate.R
@@ -43,4 +43,11 @@ test_that("If there are not enough points to construct a simplex, an error is th
   expect_error(triangulate(diag(2)))
 })
 
+test_that("Small values (1e-7 and below) of a do not lead to an error", {
+  # Use a small triangle to make the computational effort bearable
+  p <- pslg(P=rbind(c(0,0),c(1e-5,0),c(0,1e-5)))
 
+  tp <- triangulate(p,a=1e-7)
+  tp <- triangulate(p,a=1e-8)
+  tp <- triangulate(p,a=1e-9)
+})


### PR DESCRIPTION
I've tested this as follows:

```
rm -f RTriangle_1.6-0.7.tar.gz
R CMD build .
R -e 'install.packages("./RTriangle_1.6-0.7.tar.gz")'
( cd tests && R -e 'source("testthat.R")' )
```

This sequences of commands yields a test failure for the new master~1 (because a new test was added that fails) and no test failure for the new master.
