### PR TITLE
use data.frame in anyDuplicated

### DIFF
--- a/pkg/R/triangle.R
+++ b/pkg/R/triangle.R
@@ -76,7 +76,7 @@ pslg <- function(P, PB=NA, PA=NA, S=NA, SB=NA, H=NA) {
   }
 
   ## Check that there are no duplicate rows in P
-  if (anyDuplicated(P)) {
+  if (anyDuplicated(as.data.frame(P))) {  ## faster for data.frame than matrix
     stop("Duplicated vertices in P.")
   }
 


### PR DESCRIPTION
`anyDuplicated().data.frame` is faster than `anyDuplicated.matrix()`

For a simple example, creating the `pslg` takes more time than building the triangulation, but with this PR it's 3x faster. 

```R
library(RTriangle)
set.seed(98)
xy <- matrix(rnorm(1e6), ncol = 2)
system.time(sl1 <- pslg(xy))  # 10s
system.time(sl2 <- pslg2(xy))  # 3s

system.time(triangulate(sl1)) # 2s
```


as per https://github.com/davidcsterratt/RTriangle/issues/7